### PR TITLE
Model validation failed

### DIFF
--- a/models/Setting.php
+++ b/models/Setting.php
@@ -122,7 +122,7 @@ class Setting extends ActiveRecord implements SettingInterface
         }
         $model->section = $section;
         $model->key = $key;
-        $model->value = $value;
+        $model->value = strval($value);
 
         if ($type !== null) {
             $model->type = $type;


### PR DESCRIPTION
Recently YII2 version's ActiveRecord class no longer validate integer type as valid string. So need to convert it to match the DB field