### PR TITLE
Use active query condition to work with PostgreSQL

### DIFF
--- a/models/Setting.php
+++ b/models/Setting.php
@@ -102,7 +102,7 @@ class Setting extends ActiveRecord implements SettingInterface
      */
     public function getSettings()
     {
-        $settings = static::find()->where(['active' => 1])->asArray()->all();
+        $settings = static::find()->where(['active' => true])->asArray()->all();
         return array_merge_recursive(
             ArrayHelper::map($settings, 'key', 'value', 'section'),
             ArrayHelper::map($settings, 'key', 'type', 'section')

--- a/views/default/index.php
+++ b/views/default/index.php
@@ -52,7 +52,7 @@ $this->params['breadcrumbs'][] = $this->title;
                 [
                     'attribute' => 'section',
                     'filter' => ArrayHelper::map(
-                        Setting::find()->select('section')->distinct()->where('section <> ""')->all(),
+                        Setting::find()->select('section')->distinct()->where(['<>', 'section', ''])->all(),
                         'section',
                         'section'
                     ),


### PR DESCRIPTION
Original condition is not DB agnostic. Postgres needs its string formatting. Otherwise it ends up with:
````
   zero-length delimited identifier at or near """"
   LINE 1: ...ELECT DISTINCT "section" FROM "settings" WHERE section <> ""
````