### PR TITLE
implemented has method

### DIFF
--- a/components/Settings.php
+++ b/components/Settings.php
@@ -140,6 +140,41 @@ class Settings extends Component
     }
 
     /**
+     * Return if the given key and section exists.
+     * You can use dot notation to separate the section from the key:
+     * $value = $settings->has('section.key');
+     * and
+     * $value = $settings->has('key', 'section');
+     * are equivalent
+     *
+     * @param $key
+     * @param null $section
+     * @param null $default
+     * @return mixed
+     */
+    public function has($key, $section = null)
+    {
+        if (is_null($section)) {
+            $pieces = explode('.', $key, 2);
+            if (count($pieces) > 1) {
+                $section = $pieces[0];
+                $key = $pieces[1];
+            } else {
+                $section = '';
+            }
+        }
+
+        // TODO: value is uncached
+        $data = $this->model->getSettings(false);
+
+        if (isset($data[$section][$key][0])) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
      * Deletes a setting
      *
      * @param $key

--- a/models/BaseSetting.php
+++ b/models/BaseSetting.php
@@ -91,9 +91,13 @@ class BaseSetting extends ActiveRecord implements SettingInterface
     /**
      * @inheritdoc
      */
-    public function getSettings()
+    public function getSettings($onlyActive = true)
     {
-        $settings = static::find()->where(['active' => true])->asArray()->all();
+        $query = static::find();
+        if ($onlyActive === true) {
+            $query->where(['active' => true]);
+        }
+        $settings = $query->asArray()->all();
         return array_merge_recursive(
             ArrayHelper::map($settings, 'key', 'value', 'section'),
             ArrayHelper::map($settings, 'key', 'type', 'section')

--- a/models/SettingInterface.php
+++ b/models/SettingInterface.php
@@ -20,7 +20,7 @@ interface SettingInterface
      * Gets a combined map of all the settings.
      * @return array
      */
-    public function getSettings();
+    public function getSettings($activeOnly = true);
 
     /**
      * Saves a setting


### PR DESCRIPTION
This is related to https://github.com/phemellc/yii2-settings/issues/37#issuecomment-182534510

**Note!** This is implemented in an uncached version, which is not ideal.
But I ran into some complications, because I'd need to cache "all" values instead "active" (current default).
This also applies to `_data` which would also have to distinguish between "all" and "active".

Let me know your thoughts.

Btw: Is it by design that a `key` can exist twice? 