### PR TITLE
[WIP] also settype for object (BC)

### DIFF
--- a/components/Settings.php
+++ b/components/Settings.php
@@ -109,7 +109,7 @@ class Settings extends Component
         $data = $this->getRawConfig();
 
         if (isset($data[$section][$key][0])) {
-            if (in_array($data[$section][$key][1], ['boolean', 'bool', 'integer', 'int', 'float', 'string', 'array'])) {
+            if (in_array($data[$section][$key][1], ['object', 'boolean', 'bool', 'integer', 'int', 'float', 'string', 'array'])) {
                 settype($data[$section][$key][0], $data[$section][$key][1]);
             }
         } else {


### PR DESCRIPTION
related to #50 

This is just a quick BC-fix.

Maybe we can make the types for `settype` configurable?

[edit]

Or introduce a new type `json` instead of object, which is handled more efficiently.